### PR TITLE
Bump version to RabbitMQ 3.6.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rabbitmq:3.5.3-management
+FROM rabbitmq:3.6.2-management
 MAINTAINER Dimitris Kapanidis dimitris.kapanidis@harbur.io
 
 COPY rabbitmq-cluster /usr/local/bin/


### PR DESCRIPTION
Tested with the current docker base image of RabbitMQ. 
